### PR TITLE
MTL-2346 `ModuleNotFoundError: No module named 'DataSourcenocloud-net;s=`

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+23.2.2
+ - Fix NoCloud kernel commandline key parsing (#4273) (Fixes: #4271)
+   (LP: #2028562)
+ - Fix reference before assignment (#4292) (Fixes: #4288) (LP: #2028784)
+
 23.2.1
     - nocloud: parse_cmdline no longer detects nocloud-net datasource (#4204)
       (Fixes: 4203) (LP: #2025180)

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,6 @@
+23.2.1
+    - nocloud: parse_cmdline no longer detects nocloud-net datasource (#4204)
+      (Fixes: 4203) (LP: #2025180)
 23.2
  - BSD: simplify finding MBR partitions by removing duplicate code
    [Mina Galić]

--- a/cloudinit/importer.py
+++ b/cloudinit/importer.py
@@ -40,16 +40,16 @@ def match_case_insensitive_module_name(mod_name: str) -> Optional[str]:
     if "nocloud-net" == mod_name.lower():
         mod_name = mod_name[:-4]
     if not mod_name.startswith("DataSource"):
-        ds_name = f"DataSource{mod_name}"
+        mod_name = f"DataSource{mod_name}"
     modules = {}
     spec = importlib.util.find_spec("cloudinit.sources")
     if spec and spec.submodule_search_locations:
         for dir in spec.submodule_search_locations:
             modules.update(util.get_modules_from_dir(dir))
         for module in modules.values():
-            if module.lower() == ds_name.lower():
+            if module.lower() == mod_name.lower():
                 return module
-    return ds_name
+    return mod_name
 
 
 def find_module(

--- a/cloudinit/sources/__init__.py
+++ b/cloudinit/sources/__init__.py
@@ -365,7 +365,10 @@ class DataSource(CloudInitPickleMixin, metaclass=abc.ABCMeta):
         if self.override_ds_detect():
             return self._get_data()
         elif self.ds_detect():
-            LOG.debug("Machine is running on %s.", self)
+            LOG.debug(
+                "Detected platform: %s. Checking for active instance data",
+                self,
+            )
             return self._get_data()
         else:
             LOG.debug("Datasource type %s is not detected.", self)
@@ -1177,9 +1180,9 @@ def parse_cmdline() -> str:
     Passing by command line overrides runtime datasource detection
     """
     cmdline = util.get_cmdline()
-    ds_parse_0 = re.search(r"ds=([a-zA-Z]+)(\s|$|;)", cmdline)
-    ds_parse_1 = re.search(r"ci\.ds=([a-zA-Z]+)(\s|$|;)", cmdline)
-    ds_parse_2 = re.search(r"ci\.datasource=([a-zA-Z]+)(\s|$|;)", cmdline)
+    ds_parse_0 = re.search(r"ds=([^\s;]+)", cmdline)
+    ds_parse_1 = re.search(r"ci\.ds=([^\s;]+)", cmdline)
+    ds_parse_2 = re.search(r"ci\.datasource=([^\s;]+)", cmdline)
     ds = ds_parse_0 or ds_parse_1 or ds_parse_2
     deprecated = ds_parse_1 or ds_parse_2
     if deprecated:

--- a/cloudinit/version.py
+++ b/cloudinit/version.py
@@ -4,7 +4,7 @@
 #
 # This file is part of cloud-init. See LICENSE file for license information.
 
-__VERSION__ = "23.2.1"
+__VERSION__ = "23.2.2"
 _PACKAGED_VERSION = "@@PACKAGED_VERSION@@"
 
 FEATURES = [

--- a/cloudinit/version.py
+++ b/cloudinit/version.py
@@ -4,7 +4,7 @@
 #
 # This file is part of cloud-init. See LICENSE file for license information.
 
-__VERSION__ = "23.2"
+__VERSION__ = "23.2.1"
 _PACKAGED_VERSION = "@@PACKAGED_VERSION@@"
 
 FEATURES = [

--- a/tests/data/kernel_cmdline_match/meta-data
+++ b/tests/data/kernel_cmdline_match/meta-data
@@ -1,0 +1,1 @@
+instance=id: dfa16c21-4b25-4767-b94c-f98f5d73736d

--- a/tests/data/kernel_cmdline_match/user-data
+++ b/tests/data/kernel_cmdline_match/user-data
@@ -1,0 +1,3 @@
+#cloud-config
+runcmd:
+- touch /cmdline-userdata-success

--- a/tests/data/kernel_cmdline_match/vendor-data
+++ b/tests/data/kernel_cmdline_match/vendor-data
@@ -1,0 +1,2 @@
+#cloud-config
+{}

--- a/tests/integration_tests/cmd/test_status.py
+++ b/tests/integration_tests/cmd/test_status.py
@@ -1,33 +1,11 @@
 """Tests for `cloud-init status`"""
-from time import sleep
-
 import pytest
 
 from tests.integration_tests.clouds import IntegrationCloud
 from tests.integration_tests.instances import IntegrationInstance
 from tests.integration_tests.integration_settings import PLATFORM
 from tests.integration_tests.releases import CURRENT_RELEASE, IS_UBUNTU, JAMMY
-
-
-# We're implementing our own here in case cloud-init status --wait
-# isn't working correctly (LP: #1966085)
-def _wait_for_cloud_init(client: IntegrationInstance):
-    last_exception = None
-    for _ in range(30):
-        try:
-            result = client.execute("cloud-init status")
-            if (
-                result
-                and result.ok
-                and ("running" not in result or "not run" not in result)
-            ):
-                return result
-        except Exception as e:
-            last_exception = e
-        sleep(1)
-    raise Exception(
-        "cloud-init status did not return successfully."
-    ) from last_exception
+from tests.integration_tests.util import wait_for_cloud_init
 
 
 def _remove_nocloud_dir_and_reboot(client: IntegrationInstance):
@@ -66,6 +44,7 @@ def test_wait_when_no_datasource(session_cloud: IntegrationCloud, setup_image):
         # Jammy and above will use LXD datasource by default
         if CURRENT_RELEASE < JAMMY:
             _remove_nocloud_dir_and_reboot(client)
-        status_out = _wait_for_cloud_init(client).stdout.strip()
+        status_out = wait_for_cloud_init(client).stdout.strip()
         assert "status: disabled" in status_out
         assert client.execute("cloud-init status --wait").ok
+        assert client.execute("test -f /cmdline-userdata-success").ok

--- a/tests/integration_tests/conftest.py
+++ b/tests/integration_tests/conftest.py
@@ -206,7 +206,6 @@ def _client(
     lxd_use_exec = fixture_utils.closest_marker_args_or(
         request, "lxd_use_exec", None
     )
-
     launch_kwargs = {}
     if name is not None:
         launch_kwargs["name"] = name

--- a/tests/integration_tests/test_kernel_commandline_match.py
+++ b/tests/integration_tests/test_kernel_commandline_match.py
@@ -66,7 +66,7 @@ def override_kernel_cmdline(ds_str: str, c: IntegrationInstance) -> str:
     "ds_str, configured",
     (
         (
-            "ds=nocloud;s=http://my-url/",
+            "ds=nocloud;s=http://my-url/;h=hostname",
             "DataSourceNoCloud [seed=None][dsmode=net]",
         ),
         ("ci.ds=openstack", "DataSourceOpenStack"),

--- a/tests/integration_tests/test_kernel_commandline_match.py
+++ b/tests/integration_tests/test_kernel_commandline_match.py
@@ -1,7 +1,14 @@
+import logging
+
 import pytest
 
+from tests.integration_tests.clouds import IntegrationCloud
+from tests.integration_tests.conftest import get_validated_source
 from tests.integration_tests.instances import IntegrationInstance
 from tests.integration_tests.integration_settings import PLATFORM
+from tests.integration_tests.util import wait_for_cloud_init
+
+log = logging.getLogger("integration_testing")
 
 
 def override_kernel_cmdline(ds_str: str, c: IntegrationInstance) -> str:
@@ -37,7 +44,16 @@ def override_kernel_cmdline(ds_str: str, c: IntegrationInstance) -> str:
     # most likely be as simple as updating the output path for grub-mkconfig
     client.execute("grub-mkconfig -o /boot/efi/EFI/ubuntu/grub.cfg")
     client.execute("cloud-init clean --logs")
-    client.instance.shutdown()
+    client.instance.shutdown(wait=False)
+    try:
+        client.instance.wait_for_state("STOPPED", num_retries=20)
+    except RuntimeError as e:
+        log.warning(
+            "Retrying shutdown due to timeout on initial shutdown request %s",
+            str(e),
+        )
+        client.instance.shutdown()
+
     client.instance.execute_via_ssh = False
     client.instance.start()
     client.execute("cloud-init status --wait")
@@ -75,18 +91,51 @@ def test_lxd_datasource_kernel_override(
     ) in override_kernel_cmdline(ds_str, client)
 
 
+GH_REPO_PATH = "https://raw.githubusercontent.com/canonical/cloud-init/main/"
+
+
 @pytest.mark.skipif(PLATFORM != "lxd_vm", reason="Modifies grub config")
 @pytest.mark.lxd_use_exec
-@pytest.mark.parametrize("ds_str", ("ci.ds=nocloud-net",))
+@pytest.mark.parametrize(
+    "ds_str",
+    (f"ds=nocloud-net;s={GH_REPO_PATH}tests/data/kernel_cmdline_match/",),
+)
 def test_lxd_datasource_kernel_override_nocloud_net(
-    ds_str, client: IntegrationInstance
+    ds_str, session_cloud: IntegrationCloud
 ):
     """NoCloud requirements vary slightly from other datasources with parsing
     nocloud-net due to historical reasons. Do to this variation, this is
     implemented in NoCloud's ds_detect and therefore has a different log
     message.
     """
-
-    assert (
-        "Machine is running on DataSourceNoCloud [seed=None][dsmode=net]."
-    ) in override_kernel_cmdline(ds_str, client)
+    _ds_name, _, seed_url = ds_str.partition(";")
+    _key, _, url_val = seed_url.partition("=")
+    source = get_validated_source(session_cloud)
+    with session_cloud.launch(
+        launch_kwargs={
+            # On Jammy and above, we detect the LXD datasource using a
+            # socket available to the container. This prevents the socket
+            # from being exposed in the container, so LXD will not be detected.
+            # This allows us to wait for detection in 'init' stage with
+            # DataSourceNoCloudNet.
+            "config_dict": {"security.devlxd": False},
+            "wait": False,  # to prevent cloud-init status --wait
+        }
+    ) as client:
+        # We know this will be an LXD instance due to our pytest mark
+        client.instance.execute_via_ssh = False  # pyright: ignore
+        assert wait_for_cloud_init(client, num_retries=60).ok
+        if source.installs_new_version():
+            client.install_new_cloud_init(
+                source, take_snapshot=False, clean=False
+            )
+        logs = override_kernel_cmdline(ds_str, client)
+        assert (
+            "nocloud"
+            == client.execute("cloud-init query platform").stdout.strip()
+        )
+        assert url_val in client.execute("cloud-init query subplatform").stdout
+        assert (
+            "Detected platform: DataSourceNoCloudNet [seed=None]"
+            "[dsmode=net]. Checking for active instance data"
+        ) in logs

--- a/tests/integration_tests/util.py
+++ b/tests/integration_tests/util.py
@@ -155,6 +155,27 @@ def get_test_rsa_keypair(key_name: str = "test1") -> key_pair:
     return key_pair(public_key, private_key)
 
 
+# We're implementing our own here in case cloud-init status --wait
+# isn't working correctly (LP: #1966085)
+def wait_for_cloud_init(client: IntegrationInstance, num_retries: int = 30):
+    last_exception = None
+    for _ in range(num_retries):
+        try:
+            result = client.execute("cloud-init status")
+            if (
+                result
+                and result.ok
+                and ("running" not in result or "not run" not in result)
+            ):
+                return result
+        except Exception as e:
+            last_exception = e
+        time.sleep(1)
+    raise Exception(
+        "cloud-init status did not return successfully."
+    ) from last_exception
+
+
 def get_console_log(client: IntegrationInstance):
     try:
         console_log = client.instance.console_log()

--- a/tests/unittests/sources/test___init__.py
+++ b/tests/unittests/sources/test___init__.py
@@ -4,42 +4,45 @@ from cloudinit import sources
 from cloudinit.sources import DataSourceOpenStack as ds
 from tests.unittests.helpers import mock
 
+openstack_ds_name = ds.DataSourceOpenStack.dsname.lower()
+
 
 @pytest.mark.parametrize(
-    "m_cmdline",
+    "m_cmdline, expected_ds",
     (
         # test ci.ds=
-        "aosiejfoij ci.ds=OpenStack ",
-        "ci.ds=OpenStack",
-        "aosiejfoij ci.ds=OpenStack blah",
-        "aosiejfoij ci.ds=OpenStack faljskebflk",
-        "ci.ds=OpenStack;",
-        "ci.ds=openstack;",
+        ("aosiejfoij ci.ds=OpenStack ", openstack_ds_name),
+        ("ci.ds=OpenStack", openstack_ds_name),
+        ("aosiejfoij ci.ds=OpenStack blah", openstack_ds_name),
+        ("aosiejfoij ci.ds=OpenStack faljskebflk", openstack_ds_name),
+        ("ci.ds=OpenStack;", openstack_ds_name),
+        ("ci.ds=openstack;", openstack_ds_name),
         # test ci.datasource=
-        "aosiejfoij ci.datasource=OpenStack ",
-        "ci.datasource=OpenStack",
-        "aosiejfoij ci.datasource=OpenStack blah",
-        "aosiejfoij ci.datasource=OpenStack faljskebflk",
-        "ci.datasource=OpenStack;",
-        "ci.datasource=openstack;",
+        ("aosiejfoij ci.datasource=OpenStack ", openstack_ds_name),
+        ("ci.datasource=OpenStack", openstack_ds_name),
+        ("aosiejfoij ci.datasource=OpenStack blah", openstack_ds_name),
+        ("aosiejfoij ci.datasource=OpenStack faljskebflk", openstack_ds_name),
+        ("ci.datasource=OpenStack;", openstack_ds_name),
+        ("ci.datasource=openstack;", openstack_ds_name),
         # weird whitespace
-        "ci.datasource=OpenStack\n",
-        "ci.datasource=OpenStack\t",
-        "ci.datasource=OpenStack\r",
-        "ci.datasource=OpenStack\v",
-        "ci.ds=OpenStack\n",
-        "ci.ds=OpenStack\t",
-        "ci.ds=OpenStack\r",
-        "ci.ds=OpenStack\v",
+        ("ci.datasource=OpenStack\n", openstack_ds_name),
+        ("ci.datasource=OpenStack\t", openstack_ds_name),
+        ("ci.datasource=OpenStack\r", openstack_ds_name),
+        ("ci.datasource=OpenStack\v", openstack_ds_name),
+        ("ci.ds=OpenStack\n", openstack_ds_name),
+        ("ci.ds=OpenStack\t", openstack_ds_name),
+        ("ci.ds=OpenStack\r", openstack_ds_name),
+        ("ci.ds=OpenStack\v", openstack_ds_name),
+        ("ci.ds=nocloud-net\v", "nocloud-net"),
+        ("ci.datasource=nocloud\v", "nocloud"),
     ),
 )
-def test_ds_detect_kernel_commandline(m_cmdline):
+def test_ds_detect_kernel_commandline(m_cmdline, expected_ds):
     """check commandline match"""
     with mock.patch(
         "cloudinit.util.get_cmdline",
         return_value=m_cmdline,
     ):
         assert (
-            ds.DataSourceOpenStack.dsname.lower()
-            == sources.parse_cmdline().lower()
+            expected_ds == sources.parse_cmdline().lower()
         ), f"could not parse [{m_cmdline}]"

--- a/tests/unittests/test_importer.py
+++ b/tests/unittests/test_importer.py
@@ -1,0 +1,24 @@
+import pytest
+
+from cloudinit.importer import match_case_insensitive_module_name
+
+
+@pytest.mark.parametrize(
+    "m_name,m_match",
+    (
+        pytest.param(
+            "nocloud-net",
+            "DataSourceNoCloud",
+            id="nocloud-net is a special case, make sure it works",
+        ),
+        pytest.param(
+            "nocloud",
+            "DataSourceNoCloud",
+            id="nocloud is a special case, make sure it works",
+        ),
+        pytest.param("DataSourceGCE", "DataSourceGCE", id="gce, full name"),
+        pytest.param("gce", "DataSourceGCE", id="gce, name match"),
+    ),
+)
+def test_importer(m_name, m_match):
+    assert m_match == match_case_insensitive_module_name(m_name)

--- a/tools/ds-identify
+++ b/tools/ds-identify
@@ -1740,8 +1740,8 @@ read_config() {
         key=${tok%%=*}
         val=${tok#*=}
 
-        # discard anything after delimiter
-        val=${val%;*}
+        # discard anything after the first delimiter
+        val=${val%%;*}
         case "$key" in
             ds) _rc_dsname="$val";;
             ci.ds) _rc_dsname="$val";;


### PR DESCRIPTION
Pull in fixes from upstream for addressing NoCloud kernel commandline key parsing.

https://github.com/canonical/cloud-init/issues/4302#issuecomment-1675999007