### PR TITLE
MTL-2490: fix broken logging in cc_timezone module

### DIFF
--- a/cloudinit/config/cc_timezone.py
+++ b/cloudinit/config/cc_timezone.py
@@ -58,14 +58,14 @@ def handle(name: str, cfg: Config, cloud: Cloud, args: list) -> None:
         timezone = 'LOCAL'
 
     if exists('/etc/adjtime'):
-        log.debug("/etc/adjtime exists")
+        LOG.debug("/etc/adjtime exists")
         with open('/etc/adjtime', 'r') as file:
             # read a list of lines into data
             content = file.readlines()
 
         hwclock_tz = timezone + '\n'
 
-        log.debug("Setting hwclock to %s", hwclock_tz)
+        LOG.debug("Setting hwclock to %s", hwclock_tz)
 
         # now change the 3rd line
         content[2] = hwclock_tz


### PR DESCRIPTION
when we merged
https://github.com/Cray-HPE/cloud-init/commit/baad0946758a406201b0b17acbd03b27d1d46f2c from upstream, we neglected to update our lowercase `log` variable to `LOG`.

Fixes MTL-2490